### PR TITLE
Added self calibration routine on boot

### DIFF
--- a/firmware/src/cell.h
+++ b/firmware/src/cell.h
@@ -28,6 +28,7 @@ public:
     void setLDOVoltage(float voltage);
     float getBuckVoltage();
     void setBuckVoltage(float voltage);
+    void calibrate();
     uint8_t GPIO_STATE = 0b00000000;
 
 private:
@@ -80,8 +81,14 @@ private:
     const float MAX_LDO_VOLTAGE = 4.5;
 
     // Calibration points
-    const std::pair<float, float> BUCK_SETPOINTS[2] = {{234, 4.5971}, {2625, 1.5041}};
-    const std::pair<float, float> LDO_SETPOINTS[2] = {{42, 4.5176}, {3760, 0.3334}};
+    static const int NUM_POINTS = 32;
+    // Each pair is defined as {measured voltage, DAC setpoint}
+    std::pair<float, float> BUCK_SETPOINTS[NUM_POINTS] = {
+        {4.5971, 234}, {1.5041, 2625}
+    };
+    std::pair<float, float> LDO_SETPOINTS[NUM_POINTS] = {
+        {4.5176, 42}, {0.3334, 3760}
+    };
 };
 
 #endif // CELL_H

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -128,7 +128,7 @@ void setup()
         cell.init();
         cell.enable();
         cell.turnOnOutputRelay();
-        delay(10);
+        cell.calibrate();
     }
 
     FastLED.addLeds<NEOPIXEL, ledPin>(leds, NUM_LEDS);
@@ -175,7 +175,7 @@ void processUARTCommands() {
             }
             float volt = cells[cellNumber - 1].getVoltage();
             USBSerial.print("OK:voltage:");
-            USBSerial.println(volt);
+            USBSerial.println(volt, 5);
         } else if (command == "ENABLE_OUTPUT") {
             int cellNumber = args.toInt();
             if (cellNumber < 1 || cellNumber > 16) {
@@ -281,6 +281,20 @@ void processUARTCommands() {
             USBSerial.println("OK:all_load_switches_disabled");
         } else if (command == "PING") {
             USBSerial.println("OK:PONG");
+        } else if (command == "CALIBRATE") {
+            int cell_num = args.toInt();
+            if (cell_num < 1 || cell_num > 16) {
+                USBSerial.println("Error:cell number must be between 1 and 16");
+                return;
+            }
+            cells[cell_num - 1].calibrate();
+
+            USBSerial.println("OK:calibrated");
+        } else if (command == "CALIBRATE_ALL") {
+            for (int i = 0; i < 16; i++) {
+                cells[i].calibrate();
+            }
+            USBSerial.println("OK:all_calibrated");
         } else {
             USBSerial.println("Error:unknown command");
         }

--- a/lib/cellsim.py
+++ b/lib/cellsim.py
@@ -21,7 +21,7 @@ class CellSim:
             stripped = line.strip()
             if stripped.startswith("OK:voltage:"):
                 try:
-                    return float(stripped[len("OK:voltage:"):])
+                    return round(float(stripped[len("OK:voltage:"):]), 6)
                 except Exception:
                     pass
             elif stripped.startswith("Error:"):
@@ -128,3 +128,19 @@ class CellSim:
     def close(self):
         """Close the underlying serial connection."""
         self.client.close() 
+
+    def calibrate(self, channel: int):
+        """Calibrate the given cell channel (1-16)."""
+        cmd = f"CALIBRATE {channel}"
+        response = self.client.send_command(cmd)
+        if response and "OK:calibrated" in response[0]:
+            return response
+        raise Exception("Calibration failed")
+
+    def calibrateAll(self):
+        """Calibrate all 16 cells."""
+        cmd = "CALIBRATE_ALL"
+        response = self.client.send_command(cmd)
+        if response and "OK:all_calibrated" in response[0]:
+            return response
+        raise Exception("Calibration failed")


### PR DESCRIPTION
Each cell will now self calibrate using the onboard ADC:
- Measures output voltage at 32 setpoints across range
- Stores values in calibration array
- calculateSetpoint function finds bracketing calibration values for a requested voltage and linearly interpolates between them.
- Calibration happens on boot, values are not currently persisted.